### PR TITLE
Add onBlock handler to Menu component for improved interaction control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.1] - 2026-05-11
+
+### Added
+
+- **`Menu` component**: `onBlock` prop added — when `isBlocked` is `true` and `onBlock` is provided, the trigger button redirects to `onBlock` instead of opening the menu; propagated to all three internal `Button` variants (single-option, ICON, PRIMARY)
+
 ## [1.24.0] - 2026-05-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unoff/ui",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unoff/ui",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "license": "MIT",
       "dependencies": {
         "@unoff/utils": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unoff/ui",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "type": "module",
   "description": "Unoff UI is a comprehensive library of UI components designed specifically for building Figma and Penpot plugins. It leverages modern tools and frameworks to ensure a seamless development experience.",
   "repository": {

--- a/src/components/actions/menu/Menu.tsx
+++ b/src/components/actions/menu/Menu.tsx
@@ -97,6 +97,10 @@ export interface MenuProps {
    * Label shown when no options match the search query
    */
   noResultsLabel?: string
+  /**
+   * Handler called instead of opening the menu when isBlocked is true
+   */
+  onBlock?: React.MouseEventHandler & React.KeyboardEventHandler
 }
 
 export interface MenuState {
@@ -266,6 +270,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
       alignment,
       isBlocked,
       isNew,
+      onBlock,
       containerId,
       canBeSearched,
       searchLabel,
@@ -298,6 +303,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
           isDisabled={state === 'DISABLED'}
           isBlocked={isBlocked || option.isBlocked}
           isNew={option.isNew}
+          onBlock={onBlock}
           action={
             state !== 'DISABLED'
               ? (e: React.MouseEvent<Element> | React.KeyboardEvent<Element>) =>
@@ -331,6 +337,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
             isDisabled={state === 'DISABLED'}
             isBlocked={isBlocked}
             isNew={isNew}
+            onBlock={onBlock}
             ref={this.buttonRef}
             action={(e) =>
               state !== 'DISABLED' ? this.onOpenMenu(e) : undefined
@@ -351,6 +358,7 @@ export default class Menu extends React.Component<MenuProps, MenuState> {
             isDisabled={state === 'DISABLED'}
             isBlocked={isBlocked}
             isNew={isNew}
+            onBlock={onBlock}
             ref={this.buttonRef}
             action={(e) =>
               state !== 'DISABLED' ? this.onOpenMenu(e) : undefined

--- a/src/stories/actions/Menu.stories.tsx
+++ b/src/stories/actions/Menu.stories.tsx
@@ -10,6 +10,12 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  args: {
+    onBlock: fn(),
+  },
+  argTypes: {
+    onBlock: { control: false },
+  },
 } satisfies Meta<typeof Menu>
 
 export default meta


### PR DESCRIPTION
Introduce an `onBlock` prop to the Menu component, allowing for enhanced interaction handling when the component is in a blocked state. This change improves user experience by redirecting to the specified handler instead of opening the menu when blocked. Update version to 1.24.1.