### PR TITLE
Update React and ReactDOM peerDependencies to optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,16 @@
     "@unoff/utils": "^0.8.2"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">=16",
+    "react-dom": ">=16"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.1.1",


### PR DESCRIPTION
Make React and ReactDOM peerDependencies optional and compatible with versions >=16 to resolve conflicts with Preact in scaffolded templates.