### PR TITLE
Allow simple items to stretch by adjusting min-width and overflow properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.24.4] - 2026-07-16
+
+### Fixed
+
+- **`SimpleItem` layout**: `min-width` and `overflow: hidden` added to `.simple-item__left` — prevents flex item from overflowing its container and allows content to stretch and truncate correctly
+
 ## [1.24.3] - 2026-06-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@unoff/ui",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unoff/ui",
-      "version": "1.24.3",
+      "version": "1.24.4",
       "license": "MIT",
       "dependencies": {
         "@unoff/utils": "^0.8.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unoff/ui",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "type": "module",
   "description": "Unoff UI is a comprehensive library of UI components designed specifically for building Figma and Penpot plugins. It leverages modern tools and frameworks to ensure a seamless development experience.",
   "repository": {

--- a/src/components/slots/simple-item/simple-item.scss
+++ b/src/components/slots/simple-item/simple-item.scss
@@ -56,6 +56,8 @@
 
   .simple-item__left {
     flex: 1;
+    min-width: var(--size-null);
+    overflow: hidden;
   }
 
   .simple-item__param {


### PR DESCRIPTION
Adjustments to the min-width and overflow properties enable simple items to stretch properly within their container.